### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/DCP.cpp
+++ b/src/DCP.cpp
@@ -406,7 +406,7 @@ CPS* DCP::cps(CTRL& ctrl){
       dpdv->z = cList.sslb(dpdv->z, Lambda, false); 
       ts = cList.smss(dpdv->s).max();
       tz = cList.smss(dpdv->z).max();
-      ss << 0.0 << ts << tz << endr;
+      ss = { 0.0, ts, tz };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;

--- a/src/DLP.cpp
+++ b/src/DLP.cpp
@@ -474,7 +474,7 @@ CPS* DLP::cps(CTRL& ctrl){
       tz = cList.smss(dpdv2->z).max();
       tt = -dpdv2->tau / lg;
       tk = -dpdv2->kappa / lg;
-      ss << 0.0 << ts << tz << tt << tk << endr;
+      ss = { 0.0, ts, tz, tt, tk };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;

--- a/src/DNL.cpp
+++ b/src/DNL.cpp
@@ -314,7 +314,7 @@ CPS* DNL::cps(CTRL& ctrl){
       dpdv->z = cList.sslb(dpdv->z, Lambda, false); 
       ts = cList.smss(dpdv->s).max();
       tz = cList.smss(dpdv->z).max();
-      ss << 0.0 << ts << tz << endr;
+      ss = { 0.0, ts, tz };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;

--- a/src/DQP.cpp
+++ b/src/DQP.cpp
@@ -337,7 +337,7 @@ CPS* DQP::cps(CTRL& ctrl){
 
       ts = cList.smss(dpdv->s).max();
       tz = cList.smss(dpdv->z).max();
-      ss << 0.0 << ts << tz << endr;
+      ss = { 0.0, ts, tz };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;

--- a/src/GPP.cpp
+++ b/src/GPP.cpp
@@ -273,7 +273,7 @@ CPS* gpp(std::vector<mat> FList, std::vector<mat> gList, CONEC& cList, mat A, ma
       dpdv->z = cList.sslb(dpdv->z, Lambda, false); 
       ts = cList.smss(dpdv->s).max();
       tz = cList.smss(dpdv->z).max();
-      ss << 0.0 << ts << tz << endr;
+      ss = { 0.0, ts, tz };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;

--- a/src/RPP.cpp
+++ b/src/RPP.cpp
@@ -222,7 +222,7 @@ CPS* rpp(mat x0, mat P, mat mrc, CTRL& ctrl){
       dpdv->z = cList.sslb(dpdv->z, Lambda, false); 
       ts = cList.smss(dpdv->s).max();
       tz = cList.smss(dpdv->z).max();
-      ss << 0.0 << ts << tz << endr;
+      ss = { 0.0, ts, tz };
       tm = ss.max();
       if(tm == 0.0){
 	step = 1.0;


### PR DESCRIPTION
Lieber Bernhard,

These six one-line changes update RcppArmadillo from the now
deprecated `<<` initialization to brace initialization allowed since
C++11 and long been the minimal standard with R too.  It would be
great if you could merge this, and release and updated package "in the
next little while" -- see the two prior emails I sent, and the
transition log at RcppCore/RcppArmadillo#391

Oh, and tested with CRAN 0.2-7 and GitHub 0.2-8.

Gruesse und Tschoe,  Dirk