### PR TITLE
Update matrix and vector initialization

### DIFF
--- a/src/RPP.cpp
+++ b/src/RPP.cpp
@@ -6,7 +6,7 @@ using namespace arma;
 
 CPS* rpp(mat x0, mat P, mat mrc, CTRL& ctrl){
   // Initializing objects
-  int ne = P.n_cols;
+  unsigned int ne = P.n_cols;
   int n = ne + 1;
   // Constraints
   CONEC cList, cEpi;
@@ -20,9 +20,9 @@ CPS* rpp(mat x0, mat P, mat mrc, CTRL& ctrl){
   cList.G.insert_rows(0, 1);
   cList.G(0, ne) = -1.0;
   cList.h.zeros(n, 1);
-  cList.dims << 1 << ne << endr;
-  cList.sidx << 0 << 0 << endr
-	     << 1 << ne << endr;
+  cList.dims = { 1, ne };
+  cList.sidx = { { 0, 0 }, 
+	         { 1, ne } };
   cList.K = 2;
   cList.n = n;
   // Primal dual variables


### PR DESCRIPTION
Very sorry about apparently having forgotten one change set in pull request #3 I sent a few months ago, and which you kindly merged, and updated at CRAN.   Because of my oversight, we will need another round.  It would be much appreciated if you could do another (trivial, my bad for the extra work) round at CRAN.  

(We could upate the initialization of `G` just above similarly. C++11 brace initialization work with `x = { 1, 2, 3 };` where vector dimensions are automatic, for matrices it works row-wise as I explicitly tested so `M = { {1, 2}, {3, 4} };` becomes a matrix with rows `{1, 2}` and `{3, 4}`. 